### PR TITLE
add node resource usage stats

### DIFF
--- a/cmd/resource.go
+++ b/cmd/resource.go
@@ -33,10 +33,52 @@ var resourceNamespaceCmd = &cobra.Command{
 	},
 }
 
+var resourceNodeCmd = &cobra.Command{
+	Use:   "node",
+	Short: "Calculate resource usage stats per Node",
+	Long:  `Segregates info on Allocatable, daemonsets and pods CPU requests and usage`,
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		nUtil, err := kc.NodeUsage(context.Background(), args[0])
+		if err != nil {
+			fmt.Println(err.Error())
+			return
+		}
+		fmt.Printf(`Total CPU: %.2f
+Total Memory: %.2f
+Allocatable CPU: %.2f (%.2f%%)
+Allocatable Memory: %.2f (%.2f%%)
+Requested CPU: %.2f (%.2f%%)
+Requested Memory: %.2f (%.2f%%)
+Used CPU:
+Used Memory:
+Daemonset CPU: %.2f (%.2f%%)
+Daemonset Memory: %.2f (%.2f%%)
+Workload CPU: %.2f (%.2f%%)
+Workload Memory: %.2f (%.2f%%)
+Allocatable Pods: %d
+Running Pods: %d (%d%%)
+`,
+			nUtil.TotalCPU,
+			nUtil.TotalMemory,
+			nUtil.AllocatableCPU, nUtil.AllocatableCPU*100/nUtil.TotalCPU,
+			nUtil.AllocatableMemory, nUtil.AllocatableMemory*100/nUtil.TotalMemory,
+			nUtil.RequestedCPU, nUtil.RequestedCPU*100/nUtil.AllocatableCPU,
+			nUtil.RequestedMemory, nUtil.RequestedMemory*100/nUtil.AllocatableMemory,
+			nUtil.DaemonsetCPU, nUtil.DaemonsetCPU*100/nUtil.AllocatableCPU,
+			nUtil.DaemonsetMemory, nUtil.DaemonsetMemory*100/nUtil.AllocatableMemory,
+			nUtil.WorkloadCPU, nUtil.WorkloadCPU*100/nUtil.AllocatableCPU,
+			nUtil.WorkloadMemory, nUtil.WorkloadMemory*100/nUtil.AllocatableMemory,
+			nUtil.AllocatablePods,
+			nUtil.RunningPods, nUtil.RunningPods*100/nUtil.AllocatablePods)
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(resourceCmd)
 	resourceCmd.Flags().StringVarP(&exceptionNS, "exception-namespaces", "x", "", "comma separated names of namespaces to exclude")
 	resourceCmd.PersistentFlags().BoolVarP(&skipBestEffort, "skip-best-effort-pods", "s", false, "skip pods with no cpu OR memory requests")
 
 	resourceCmd.AddCommand(resourceNamespaceCmd)
+	resourceCmd.AddCommand(resourceNodeCmd)
 }

--- a/k8s/nodes.go
+++ b/k8s/nodes.go
@@ -1,17 +1,70 @@
 package k8s
 
-import "context"
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 type NodeUtilization struct {
+	TotalCPU          float64
+	TotalMemory       float64
 	AllocatableCPU    float64
 	AllocatableMemory float64
 	RequestedCPU      float64
 	RequestedMemory   float64
 	UsedCPU           float64
 	UsedMemory        float64
-	PodsPerNode       int
+	AllocatablePods   int
+	RunningPods       int
+	DaemonsetCPU      float64
+	DaemonsetMemory   float64
+	WorkloadCPU       float64
+	WorkloadMemory    float64
 }
 
-func (c *Client) NodeUsage(ctx context.Context, name string) {
+func isPodDaemonset(pod *v1.Pod) bool {
+	for _, v := range pod.OwnerReferences {
+		return v.Kind == "DaemonSet"
+	}
+	return false
+}
 
+func (c *Client) NodeUsage(ctx context.Context, name string) (*NodeUtilization, error) {
+	node, err := c.clientSet.CoreV1().Nodes().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	nUtil := NodeUtilization{
+		AllocatableCPU:    node.Status.Allocatable.Cpu().AsApproximateFloat64(),
+		AllocatableMemory: node.Status.Allocatable.Memory().AsApproximateFloat64(),
+		AllocatablePods:   int(node.Status.Allocatable.Pods().AsApproximateFloat64()),
+		TotalCPU:          node.Status.Capacity.Cpu().AsApproximateFloat64(),
+		TotalMemory:       node.Status.Capacity.Memory().AsApproximateFloat64(),
+	}
+
+	pods, err := c.clientSet.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
+		FieldSelector: fmt.Sprintf("spec.nodeName=%s", name),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pod := range pods.Items {
+		nUtil.RunningPods++
+		for _, container := range pod.Spec.Containers {
+			nUtil.RequestedCPU += container.Resources.Requests.Cpu().AsApproximateFloat64()
+			nUtil.RequestedMemory += container.Resources.Requests.Memory().AsApproximateFloat64()
+			if isPodDaemonset(&pod) {
+				nUtil.DaemonsetCPU += container.Resources.Requests.Cpu().AsApproximateFloat64()
+				nUtil.DaemonsetMemory += container.Resources.Requests.Memory().AsApproximateFloat64()
+			} else {
+				nUtil.WorkloadCPU += container.Resources.Requests.Cpu().AsApproximateFloat64()
+				nUtil.WorkloadMemory += container.Resources.Requests.Memory().AsApproximateFloat64()
+			}
+		}
+	}
+	return &nUtil, nil
 }


### PR DESCRIPTION
This will calculate the %usage of requests on a node, allocatable CPU etc.

Be careful of the percentages as they are not relative to `Total` capacity of the node, but different in each case